### PR TITLE
修复一处dts node长度获取的错误

### DIFF
--- a/acm8615/acm8615.c
+++ b/acm8615/acm8615.c
@@ -449,16 +449,13 @@ static int acm8615_i2c_probe(struct i2c_client *i2c)
 	
     int ret;
     int fw_size;
-
-
-    
-    ret = of_property_read_u8_array(dev->of_node, "acme,dsp-firmware-dsp_cfg_preboot", NULL, 0);
-    if (ret < 0) {
-        dev_err(dev, "No firmware found in DTS\n");
+    int count;
+	
+    int count = of_property_count_u8_elems(dev->of_node, "acme,dsp-firmware-dsp_cfg_preboot");
+    if (count < 1)
         return -EINVAL;
-    }
 
-    fw_size = ret;  
+    fw_size = count;  
 
     acm8615->dsp_cfg_data = devm_kmalloc(dev, fw_size, GFP_KERNEL);
     if (!acm8615->dsp_cfg_data)


### PR DESCRIPTION
参考linux内核代码，获取未知长度是用这个函数 https://elixir.bootlin.com/linux/v6.11.5/source/drivers/hwmon/aspeed-g6-pwm-tach.c#L433 